### PR TITLE
Fix #76: Improve minio_mc connectivity by updating MinIO healthcheck

### DIFF
--- a/documentation-samples/routine-load-shared-data/docker-compose.yml
+++ b/documentation-samples/routine-load-shared-data/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     entrypoint: sh
     command: '-c ''mkdir -p /minio_data/starrocks && minio server /minio_data --console-address ":9001"'''
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -27,17 +27,18 @@ services:
       - sh
       - -c
       - |
-        until mc ls minio > /dev/null 2>&1; do
-          sleep 0.5
+        until mc alias set myminio http://minio:9000 miniouser miniopassword; do
+          echo "Waiting for MinIO to be ready...";
+          sleep 1;
         done
 
-        mc alias set myminio http://minio:9000 miniouser miniopassword
         mc admin user svcacct add --access-key AAAAAAAAAAAAAAAAAAAA \
         --secret-key BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB \
         myminio \
         miniouser
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
 
   starrocks-fe:
     image: starrocks/fe-ubuntu:3.2-latest
@@ -143,3 +144,4 @@ services:
       - 8080:8080
     depends_on:
       - redpanda
+


### PR DESCRIPTION
### Why I'm doing:
Fixes issue #76 — the routine load quickstart `docker-compose.yml` fails on macOS because `minio_mc` cannot connect to the MinIO container due to an incorrect or unavailable healthcheck method.

### What I'm doing:
- Replaced the old healthcheck that used `mc ready`, which doesn't exist inside `minio/minio`
- Added a proper HTTP-based healthcheck using `/minio/health/live`
- Adjusted the `minio_mc` service to wait until `mc alias set` succeeds

### Fixes: 
#76

### What type of PR is this:
- [x] BugFix

### Does this PR entail a change in behavior?
- [x] No, this PR will not result in a change in behavior.

### Checklist:
- [x] The modified docker-compose works correctly on macOS
- [x] The PR improves cross-platform compatibility
- [x] No core StarRocks logic is changed
