### PR TITLE
Fix Go stream_load: send required Expect: 100-continue header

### DIFF
--- a/MiscDemo/stream_load/golang/README.md
+++ b/MiscDemo/stream_load/golang/README.md
@@ -32,6 +32,12 @@ standard library (`net/http`).
 2. A target table. Create it with any MySQL client:
 
    ```sql
+   CREATE DATABASE IF NOT EXISTS test;
+
+   USE test;
+   ```
+
+   ```sql
    CREATE TABLE `stream_test` (
      `id`       bigint(20)  COMMENT "",
      `id2`      bigint(20)  COMMENT "",
@@ -102,9 +108,11 @@ Go 1.21+'s built-in `GOTOOLCHAIN=auto`), just use Go 1.24 or newer on Darwin
   re-attaches it in a `CheckRedirect` hook (the Java and Python demos do the
   equivalent).
 
-- The demo deliberately does **not** send `Expect: 100-continue`. Go's
-  `net/http` (like Python's `requests`) does not replay the 100-continue
-  handshake cleanly across the FE→BE redirect.
+- The demo sends `Expect: 100-continue`. The StarRocks FE **requires** this
+  header and rejects a load without it (`There is no 100-continue header`). Go's
+  `net/http` drives the handshake across the FE→BE redirect because
+  `http.NewRequest` with a `bytes.Reader` populates `req.GetBody` (so the body is
+  replayable) and `http.DefaultTransport` uses a non-zero `ExpectContinueTimeout`.
 
 - Supplying a unique `label` header gives at-most-once semantics: re-running
   with the same label returns `Label Already Exists`.

--- a/MiscDemo/stream_load/golang/stream_load.go
+++ b/MiscDemo/stream_load/golang/stream_load.go
@@ -59,9 +59,12 @@ under the License.
 //   - The label header is optional. Supplying a unique label gives you at-most-once
 //     semantics: re-running with the same label returns "Label Already Exists".
 //
-//   - We do NOT set the "Expect: 100-continue" header. The FE answers the load
-//     request with a redirect to a BE, and Go's net/http (like Python requests)
-//     does not replay a 100-continue handshake cleanly across that redirect.
+//   - The StarRocks FE requires the "Expect: 100-continue" header on a stream
+//     load and rejects the request with "There is no 100-continue header" when it
+//     is missing. We set it explicitly. Go's net/http drives the handshake across
+//     the FE->BE redirect because http.NewRequest with a bytes.Reader populates
+//     req.GetBody (so the body is replayable) and http.DefaultTransport sets a
+//     non-zero ExpectContinueTimeout.
 
 package main
 
@@ -109,6 +112,12 @@ func streamLoad(content []byte) error {
 	}
 	req.SetBasicAuth(starrocksUser, starrocksPassword)
 	req.Header.Set("label", generateLabel())
+
+	// The FE rejects a stream load that lacks this header with the error
+	// "There is no 100-continue header". Go honors it because the request body is
+	// replayable (http.NewRequest set req.GetBody from the bytes.Reader) and
+	// http.DefaultTransport has a non-zero ExpectContinueTimeout.
+	req.Header.Set("Expect", "100-continue")
 
 	// The FE redirects the load to a BE. Go strips the Authorization header on a
 	// redirect to a different host, so we re-attach it from the original request,


### PR DESCRIPTION
## Problem

Running `MiscDemo/stream_load/golang` fails with:

```json
{
  "Status": "FAILED",
  "Message": "class com.starrocks.common.DdlException: There is no 100-continue header"
}
```

The StarRocks FE **requires** the `Expect: 100-continue` header on a stream load. The Go demo deliberately omitted it, based on an incorrect comment claiming Go's `net/http` could not replay the 100-continue handshake across the FE→BE redirect.

## Fix

Go *does* handle the handshake across the redirect:
- `http.NewRequest` with a `bytes.Reader` populates `req.GetBody`, so the body is replayable when the client follows the FE's redirect to a BE.
- `http.DefaultTransport` (used here, since no custom `Transport` is set) has `ExpectContinueTimeout: 1s`, which drives the handshake.

This PR sets `Expect: 100-continue` and corrects the misleading comments in both `stream_load.go` and the README. The README also gains the missing `CREATE DATABASE test` / `USE test` setup step the code depends on.

The Java and Python demos in the sibling directories already send this header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)